### PR TITLE
Fix UNO compile and fix/test ramp for DUE

### DIFF
--- a/analogShield.h
+++ b/analogShield.h
@@ -36,6 +36,8 @@
 /*	04/22/2014(WilliamE): Created										*/
 /*  05/27/2014(MarshallW): Modified for readability and content         */
 /*  02/16/2015(MarshallW): ChipKIT Efficiency update!                   */
+/*  06/01/2015(GordonC):  Fixed issue for Uno compile.                  */
+/*                        Tested ramp example with DUE                  */
 /*																		*/
 /*  Todo:                                                               */
 /*    - Framework for DUE added but not tested                          */
@@ -48,45 +50,44 @@
 #ifndef _analogShield_h_
 #define _analogShield_h_
 
-    #if defined(__PIC32MX__)
-        #include <WProgram.h>
-        #include <inttypes.h>
-        #include <SPI.h>
-
+	#if defined(__PIC32MX__)
+		#include <WProgram.h>
+		#include <inttypes.h>
+		#include <SPI.h>
+	
 	#elif defined(__AVR__)
 		#include <stdio.h>
 		#include <Arduino.h>
 		#include <avr/pgmspace.h>
 		
+		//define some SPI configs
+		#define SPI_CLOCK_DIV4 0x00
+		#define SPI_CLOCK_DIV16 0x01
+		#define SPI_CLOCK_DIV64 0x02
+		#define SPI_CLOCK_DIV128 0x03
+		#define SPI_CLOCK_DIV2 0x04
+		#define SPI_CLOCK_DIV8 0x05
+		#define SPI_CLOCK_DIV32 0x06
+		//#define SPI_CLOCK_DIV64 0x07
+
+		#define SPI_MODE0 0x00
+		#define SPI_MODE1 0x04
+		#define SPI_MODE2 0x08
+		#define SPI_MODE3 0x0C
+
+		#define SPI_MODE_MASK 0x0C  // CPOL = bit 3, CPHA = bit 2 on SPCR
+		#define SPI_CLOCK_MASK 0x03  // SPR1 = bit 1, SPR0 = bit 0 on SPCR
+		#define SPI_2XCLOCK_MASK 0x01  // SPI2X = bit 0 on SPSR
+
 	#elif defined (__SAM3X8E__)
 		#include <stdio.h>
 		#include <Arduino.h>
 		#include <avr/pgmspace.h>
-        #include <SPI.h>
-
-        //define some SPI configs
-        #define SPI_CLOCK_DIV4 0x00
-        #define SPI_CLOCK_DIV16 0x01
-        #define SPI_CLOCK_DIV64 0x02
-        #define SPI_CLOCK_DIV128 0x03
-        #define SPI_CLOCK_DIV2 0x04
-        #define SPI_CLOCK_DIV8 0x05
-        #define SPI_CLOCK_DIV32 0x06
-        //#define SPI_CLOCK_DIV64 0x07
-
-        #define SPI_MODE0 0x00
-        #define SPI_MODE1 0x04
-        #define SPI_MODE2 0x08
-        #define SPI_MODE3 0x0C
-
-        #define SPI_MODE_MASK 0x0C  // CPOL = bit 3, CPHA = bit 2 on SPCR
-        #define SPI_CLOCK_MASK 0x03  // SPR1 = bit 1, SPR0 = bit 0 on SPCR
-        #define SPI_2XCLOCK_MASK 0x01  // SPI2X = bit 0 on SPSR
-
+		#include <SPI.h>
 	#else //throw error
-        #error "Incorrect processor type selected"
+		#error "Incorrect processor type selected"
 	#endif
-		
+
 	#include <stdint.h>
 	
 	//pins
@@ -107,7 +108,7 @@
 		
 	public:
 	
-    #if defined(__PIC32MX__)
+    	#if defined(__PIC32MX__)
 		volatile uint32_t *ADCCSSet;
 		volatile uint32_t *ADCCSClr;
 		uint32_t ADCCSPinMask;

--- a/examples/ramp/ramp.ino
+++ b/examples/ramp/ramp.ino
@@ -34,6 +34,7 @@
 /*                                                                      */
 /*  09/01/2013 (W. Esposito): created                                   */
 /*  05/28/2014 (MWingerson): Updated for ChipKIT and release            */
+/*  06/01/2015 (GCone): Changed order of includes for DUE support       */
 /*                                                                      */
 /************************************************************************/
 
@@ -41,13 +42,21 @@
 /*  Board Support:                                                      */
 /*                                                                      */
 /*      Arduino UNO                                                     */
+/*      Arduino DUE                                                     */
 /*      ChipKIT UNO32                                                   */
 /*      ChipKit UC32                                                    */
 /*                                                                      */
 /************************************************************************/
 
+/*
+For Arduino DUE using Arduino IDE, SPI needs to be included before 
+analogShield.  analogShield calls SPI.begin during constructor 
+thus SPI needs to be constructed before analogShield
+changing the order of includes influenced the link order and 
+thus the order of global variable construction.
+*/
+#include <SPI.h>	//required for ChipKIT and Arduino DUE 
 #include <analogShield.h>   //Include to use analog shield.
-#include <SPI.h>	//required for ChipKIT but does not affect Arduino
 
 void setup()
 {


### PR DESCRIPTION
Fixed a compile issue when using the library for UNO.   Needed to move the SPI defines in the .h file.

Was able to get the ramp example working for DUE after changing the order of includes. 
